### PR TITLE
fix Audio Rec & Play Issues by using App Group

### DIFF
--- a/watchOS2Sampler WatchKit Extension/AudioRecAndPlayInterfaceController.swift
+++ b/watchOS2Sampler WatchKit Extension/AudioRecAndPlayInterfaceController.swift
@@ -38,7 +38,15 @@ class AudioRecAndPlayInterfaceController: WKInterfaceController {
     // MARK: - Private
 
     func recFileURL() -> NSURL {
-
+        
+        // Must use a shared container
+        let fileManager = NSFileManager.defaultManager()
+        let container = fileManager.containerURLForSecurityApplicationGroupIdentifier("group.xx.xx") // replace with your own identifier
+        let audioFileURL = container!.URLByAppendingPathComponent("rec.m4a")
+        
+        return audioFileURL
+        
+        /*
         let filePaths = NSSearchPathForDirectoriesInDomains(
             NSSearchPathDirectory.DocumentDirectory,
             NSSearchPathDomainMask.UserDomainMask,
@@ -48,6 +56,7 @@ class AudioRecAndPlayInterfaceController: WKInterfaceController {
         let fileUrl = NSURL.fileURLWithPath(filePath)
         
         return fileUrl
+        */
     }
     
     


### PR DESCRIPTION
As WWDC 2015 WatchKit In-Depth, Part 1 says, 

the media data about play & record must use a shared container, so it should enable App Group

and it works on a real watch device for me ( watchOS2 beta2 )
