### PR TITLE
fix: UIGraphicsGetCurrentContext works fine

### DIFF
--- a/watchOS2Sampler WatchKit App/Base.lproj/Interface.storyboard
+++ b/watchOS2Sampler WatchKit App/Base.lproj/Interface.storyboard
@@ -580,7 +580,7 @@
                                 <button width="0.5" alignment="left" title="Radial" id="k0U-qb-tff">
                                     <fontDescription key="font" type="system" pointSize="11"/>
                                     <connections>
-                                        <action selector="radicalBtnAction:" destination="SZT-52-KSP" id="vUG-yv-CY2"/>
+                                        <action selector="radialBtnTapped:" destination="SZT-52-KSP" id="XdV-Go-Qnd"/>
                                     </connections>
                                 </button>
                             </items>

--- a/watchOS2Sampler WatchKit App/Base.lproj/Interface.storyboard
+++ b/watchOS2Sampler WatchKit App/Base.lproj/Interface.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="8152.3" systemVersion="14E46" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="AgC-eL-Hgc" defaultGlanceController="0uZ-2p-rRc">
+<document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="8152.3" systemVersion="15A215h" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="AgC-eL-Hgc" defaultGlanceController="0uZ-2p-rRc">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8124.4"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBWatchKitPlugin" version="8077.2"/>
@@ -579,6 +579,9 @@
                                 </button>
                                 <button width="0.5" alignment="left" title="Radial" id="k0U-qb-tff">
                                     <fontDescription key="font" type="system" pointSize="11"/>
+                                    <connections>
+                                        <action selector="radicalBtnAction:" destination="SZT-52-KSP" id="vUG-yv-CY2"/>
+                                    </connections>
                                 </button>
                             </items>
                         </group>

--- a/watchOS2Sampler WatchKit Extension/DrawPathsInterfaceController.swift
+++ b/watchOS2Sampler WatchKit Extension/DrawPathsInterfaceController.swift
@@ -32,23 +32,6 @@ class DrawPathsInterfaceController: WKInterfaceController {
         super.didDeactivate()
     }
     
-    private func createBitmapContext(size: CGSize) -> CGContext? {
-
-        let space = CGColorSpaceCreateDeviceRGB()!
-        
-        let context = CGBitmapContextCreate(
-            nil,
-            Int(size.width),
-            Int(size.height),
-            8,
-            Int(size.width * 4),
-            space,
-            UInt32(CGImageAlphaInfo.PremultipliedLast.rawValue))
-        
-        return context
-    }
-
-    
     // =========================================================================
     // MARK: - Actions
     
@@ -57,7 +40,7 @@ class DrawPathsInterfaceController: WKInterfaceController {
         // Create a graphics context
         let size = CGSizeMake(100, 100)
         UIGraphicsBeginImageContext(size)
-        let context = createBitmapContext(size)
+        let context = UIGraphicsGetCurrentContext()
         
         // Setup for the path appearance
         CGContextSetStrokeColorWithColor(context, UIColor.whiteColor().CGColor)
@@ -86,8 +69,8 @@ class DrawPathsInterfaceController: WKInterfaceController {
         // Create a graphics context
         let size = CGSizeMake(100, 100)
         UIGraphicsBeginImageContext(size)
-        let context = createBitmapContext(size)
-        UIGraphicsPushContext(context!)
+        let context = UIGraphicsGetCurrentContext()
+        UIGraphicsPushContext(context)
         
         // Setup for the path appearance
         UIColor.greenColor().setStroke()
@@ -116,8 +99,8 @@ class DrawPathsInterfaceController: WKInterfaceController {
         // Create a graphics context
         let size = CGSizeMake(512, 512)
         UIGraphicsBeginImageContext(size)
-        let context = createBitmapContext(size)
-        UIGraphicsPushContext(context!)
+        let context = UIGraphicsGetCurrentContext()
+        UIGraphicsPushContext(context)
         
         // Setup for the path appearance
         UIColor.yellowColor().setFill()

--- a/watchOS2Sampler WatchKit Extension/GradationInterfaceController.m
+++ b/watchOS2Sampler WatchKit Extension/GradationInterfaceController.m
@@ -75,7 +75,7 @@
     [self.image setImage:uiimage];
 }
 
-- (IBAction)radicalBtnAction:(id)sender {
+- (IBAction)radialBtnTapped:(id)sender {
     CGSize size = CGSizeMake(100, 100);
     UIGraphicsBeginImageContext(size);
     CGContextRef context = UIGraphicsGetCurrentContext();

--- a/watchOS2Sampler WatchKit Extension/GradationInterfaceController.m
+++ b/watchOS2Sampler WatchKit Extension/GradationInterfaceController.m
@@ -75,6 +75,39 @@
     [self.image setImage:uiimage];
 }
 
+- (IBAction)radicalBtnAction:(id)sender {
+    CGSize size = CGSizeMake(100, 100);
+    UIGraphicsBeginImageContext(size);
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    
+    CGContextSaveGState(context);
+    
+    CFMutableArrayRef gradientColors = CFArrayCreateMutable(kCFAllocatorDefault, 2, &kCFTypeArrayCallBacks);
+    CFArrayAppendValue(gradientColors, [UIColor greenColor].CGColor);
+    CFArrayAppendValue(gradientColors, [UIColor blueColor].CGColor);
+    
+    CGPoint center = CGPointMake(50, 50);
+    CGFloat locations[2] = {
+        0, 1
+    };
+    
+    CGGradientRef gradient = CGGradientCreateWithColors(CGColorSpaceCreateDeviceRGB(), gradientColors, locations);
+    CGContextDrawRadialGradient(context, gradient, center, 0, center, sqrt(pow(50, 2) * 2), kCGGradientDrawsBeforeStartLocation);
+    CGGradientRelease(gradient);
+    CFRelease(gradientColors);
+    CGContextRestoreGState(context);
+    
+    // Convert to UIImage
+    CGImageRef cgimage = CGBitmapContextCreateImage(context);
+    UIImage *uiimage = [UIImage imageWithCGImage:cgimage];
+    
+    // End the graphics context
+    UIGraphicsEndImageContext();
+    
+    [self.image setImage:uiimage];
+}
+
+
 @end
 
 

--- a/watchOS2Sampler WatchKit Extension/GradationInterfaceController.m
+++ b/watchOS2Sampler WatchKit Extension/GradationInterfaceController.m
@@ -33,20 +33,6 @@
     [super didDeactivate];
 }
 
-- (CGContextRef)createBitmapContextWithSize:(CGSize)size {
-
-    CGColorSpaceRef space = CGColorSpaceCreateDeviceRGB();
-    CGContextRef context = CGBitmapContextCreate(nil,
-                                                 size.width,
-                                                 size.height,
-                                                 8,
-                                                 size.width * 4,
-                                                 space,
-                                                 kCGImageAlphaPremultipliedLast);
-    
-    return context;
-}
-
 // =============================================================================
 #pragma mark - Actions
 
@@ -54,7 +40,7 @@
 
     CGSize size = CGSizeMake(100, 100);
     UIGraphicsBeginImageContext(size);
-    CGContextRef context = [self createBitmapContextWithSize:size];
+    CGContextRef context = UIGraphicsGetCurrentContext();
 
     CGContextSaveGState(context);
     

--- a/watchOS2Sampler WatchKit Extension/GradationInterfaceController.m
+++ b/watchOS2Sampler WatchKit Extension/GradationInterfaceController.m
@@ -51,9 +51,9 @@
     CGPoint startPoint = CGPointMake(0, 0);
     CGPoint endPoint = CGPointMake(100, 100);
     
-    CGFloat *locations = malloc(2 * sizeof(CGFloat));
-    locations[0] = 0.0;
-    locations[1] = 1.0;
+    CGFloat locations[2] = {
+        0, 1
+    };
 
     CGGradientRef gradient = CGGradientCreateWithColors(CGColorSpaceCreateDeviceRGB(), gradientColors, locations);
     CGContextDrawLinearGradient(context,


### PR DESCRIPTION
いつもブログ拝見＆参考にさせて頂いてます。

http://d.hatena.ne.jp/shu223/20150714/1436875676

こちらの記事で

> watchOS では `UIGraphicsGetCurrentContext()` でグラフィックス コンテキストを取得できない

とありましたが、取得できました。

取得できなかったのは、スライドのTrial1のコードで、`UIGraphicsBeginImageContext`が抜けていたためだと思われます（もし`CGBitmapContextCreate`を使う場合`UIGraphicsBeginImageContext`周りが不要だと思いますがいかがでしょうか？）。UIGraphicsでの描画（`UIRectFill`など）も問題なくできました（PRには含まれていませんが）。

ついでに円形グラデーションの実装も追加しました。

レビューよろしくお願い致しますm(_ _)m
